### PR TITLE
release 1.0.2 on pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 dist
 build
 eggs
+.eggs
 parts
 bin
 var
@@ -23,9 +24,11 @@ pip-log.txt
 
 # Unit test / coverage reports
 .coverage
-.tox
+.tox/
+.cache/
+.pytest_cache/
 nosetests.xml
-htmlcov
+htmlcov/
 
 # Translations
 *.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ cache:
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"  
+  - "3.6"  
+  - "3.7"  
 install: pip install tox-travis
 script: tox
 

--- a/README.rst
+++ b/README.rst
@@ -162,3 +162,34 @@ python-обёртка вокруг API ЛитРес на базе requests и xm
     genres = api.get_genres()
     >>> genres.xpath("//genre[@token='sport_fitnes']")[0].attrib['title']
     'Спорт, фитнес'
+
+Разработка
+~~~~~~~~~~
+
+Запустить тесты
+---------------
+
+::
+
+  tox -e py37
+
+
+Публикация релиза в PyPi
+------------------------
+
+Для публикации релиза понадобится `twine <https://pypi.org/project/twine/>`_.
+Для удобства его можно установить глобально::
+
+  pip install twine
+
+1. Поднимаем версию пакета::
+
+    __version__ = '1.0.2'
+
+2. Собираем пакет::
+
+    python setup.py sdist
+
+3. Загружаем собранный пакет в PyPi::
+
+    twine upload dist/litresapi-1.0.1.tar.gz

--- a/litresapi/__init__.py
+++ b/litresapi/__init__.py
@@ -1,5 +1,5 @@
 # coding: utf-8
 # flake8: noqa
-__version__ = '1.0.0'
+__version__ = '1.0.2'
 
 from .core import LitresApi

--- a/setup.py
+++ b/setup.py
@@ -15,20 +15,17 @@ from setuptools.command.test import test as TestCommand
 
 
 class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
+    user_options = [('pytest-args=', 'a', 'Arguments to pass to pytest')]
 
     def initialize_options(self):
         TestCommand.initialize_options(self)
-        self.pytest_args = []
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
+        self.pytest_args = ''
 
     def run_tests(self):
+        import shlex
         import pytest
-        errno = pytest.main(self.pytest_args)
+
+        errno = pytest.main(shlex.split(self.pytest_args))
         sys.exit(errno)
 
 
@@ -52,25 +49,25 @@ requirements = [
 ]
 
 test_requirements = [
-    'pytest>=2.7.2',
-    'pytest-cov>=2.4.0',
-    'freezegun>=0.3.4',
-    'vcrpy>=1.6.1'
+    'pytest>=4.6.3',
+    'pytest-cov>=2.7.1',
+    'freezegun>=0.3.12',
+    'vcrpy>=2.0.1'
 ]
 
 setup(
     name='litresapi',
     version=get_version('litresapi'),
-    description="Litres API",
+    description='Litres API',
     long_description=readme + '\n\n' + history,
-    author="MyBook",
+    author='MyBook',
     author_email='dev@mybook.ru',
     url='https://github.com/MyBook/litresapi',
     packages=['litresapi'],
     package_dir={'litresapi': 'litresapi'},
     include_package_data=True,
     install_requires=requirements,
-    license="BSD",
+    license='BSD',
     zip_safe=False,
     keywords='litresapi',
     classifiers=[
@@ -78,11 +75,12 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
-        "Programming Language :: Python :: 2",
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     test_suite='tests',
     tests_require=test_requirements,

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py27, py34, py35, flake8
+envlist = py27, py35, py36, py37 flake8
 
 
 [testenv]
 deps = coverage
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/litresapi
-commands = python setup.py test -a "--cov=litresapi --cov-append"
+commands = python setup.py test -a "--cov=litresapi"
 usedevelop = true
 
 


### PR DESCRIPTION
[Release version 1.0.2 on pypi](https://pypi.org/project/litresapi/1.0.2/)

To make this release happen i had to:
* Fix tests failing due to newer pytest
* Add py36 and py37 to env list. Also I removed py3.4 from the list
* Add a bit of info how to launch tests and publish new releases on pypi 
