### PR TITLE
allow to download book covers with formats other than jpg

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,11 @@
 Changelog
 ---------
 
-1.1.1 (2020-04-06)
+1.1.2 (2020-04-14)
+------------------
+* Allow to download book covers with formats other than jpg
+
+1.1.1 (2020-04-10)
 ------------------
 * Fix request params for /get_the_book/ and cover download requests
 

--- a/litresapi/__init__.py
+++ b/litresapi/__init__.py
@@ -1,4 +1,4 @@
 # flake8: noqa
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 
 from .core import LitresApi

--- a/litresapi/core.py
+++ b/litresapi/core.py
@@ -166,7 +166,7 @@ class LitresApi(object):
             if not file_ext:
                 return None
         # we are taking max size cover
-        cover_dir = '/pub/c/cover/{}.jpg'.format(book_id)
+        cover_dir = '/pub/c/cover/{book_id}.{file_ext}'.format(book_id=book_id, file_ext=file_ext)
         response = self._request(cover_dir, domain_prefix='partnersdnld', **kwargs)
         self.check_response(response)
 


### PR DESCRIPTION
У некоторых книг обложки могут быть в формате png. get_fresh_book возвращает тип обложки атрибутом `cover` 
```
<updated-book ... cover="png" ... you_can_sell="1">
```