### PR TITLE
exception: ensure that response is not None while raising LitresAPIException 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+1.2.2 (2022-09-07)
+------------------
+* Ensure that response is not None while raising LitresAPIException
+
 1.2.1 (2021-06-15)
 ------------------
 * Add exception support for celery

--- a/litresapi/__init__.py
+++ b/litresapi/__init__.py
@@ -1,4 +1,4 @@
 # flake8: noqa
-__version__ = '1.2.1'
+__version__ = '1.2.2'
 
 from .core import LitresApi

--- a/litresapi/exceptions.py
+++ b/litresapi/exceptions.py
@@ -5,4 +5,4 @@ class LitresAPIException(Exception):
         super().__init__(message, response)
 
     def __str__(self):
-        return '%s -> %s' % (self.message, self.response.text)
+        return '%s -> %s' % (self.message, self.response.text if self.response else None)


### PR DESCRIPTION
Небольшой фикс, при котором не будет падать AttributeError, если при выполнении запроса возникло исключение и response не был получен